### PR TITLE
Retrieve run attributes directly from gpx file

### DIFF
--- a/running_dashboard/forms.py
+++ b/running_dashboard/forms.py
@@ -7,7 +7,7 @@ from django.contrib.auth.forms import UserCreationForm
 from django.contrib.auth.models import User
 
 from running_dashboard.models import Run
-from running_dashboard.util import gpxToWkt
+from running_dashboard.util import attributesFromGpx
 
 
 class ChangeRunDurationForm(forms.Form):
@@ -29,46 +29,26 @@ class ChangeRunDurationForm(forms.Form):
 
 class AddRunForm(forms.Form):
     """
-    Form that is intended to allow the user to add a new run to the db using 3 input fields.
+    Form that is intended to allow the user to add a new run to the db using an input field for a gpx file.
     The form is used by the `AddNewRun` view.
     """
 
-    start_time = forms.DateTimeField(label="Start Time", widget=forms.DateTimeInput(attrs= {'placeholder':"2019-12-31 16:30:00"}))
-    time_sec = forms.IntegerField(label="Duration")
-    route = forms.FileField(label="Route (Upload GPX file)")
+    gpx_file = forms.FileField(label="Upload GPX file")
 
-    def clean_start_time(self):
 
-        data = self.cleaned_data['start_time']
-
-        if data.date() > datetime.date.today():
-            raise forms.ValidationError("The date for this run hasn't occured yet")
-
-        return data
-
-    def clean_time_sec(self):
+    def clean_gpx_file(self):
         
-        data = self.cleaned_data['time_sec']
-
-        if data < 0:
-            raise forms.ValidationError(
-            "The run duration must be a non negative number of seconds")
-
-        return data
-
-    def clean_route(self):
-        
-        data = self.cleaned_data['route']
+        data = self.cleaned_data['gpx_file']
 
         try:
             data = data.read().decode('utf-8')
-            data = gpxToWkt(data)
+            attributes = attributesFromGpx(data)
 
         except (UnicodeDecodeError, ValueError) as e:
             raise forms.ValidationError(
-                "The file representing the route must be a gpx file")
+                "The file representing the run must be a gpx file with a recorded track")
 
-        return data
+        return attributes
 
 
     class Meta:

--- a/running_dashboard/util.py
+++ b/running_dashboard/util.py
@@ -4,7 +4,7 @@ import gpxpy
 from gpxpy.gpx import GPXXMLSyntaxException
 
 
-def gpxToWkt(gpx_string):
+def attributesFromGpx(gpx_string):
     """
     Function that receives a string containing the contents of a gpx file, parses it using
     a method from the gpxpy module and returns a string containing the well known text value
@@ -25,13 +25,25 @@ def gpxToWkt(gpx_string):
                     wkt += f"{point.longitude} {point.latitude}"
                     if index < len(segment.points) - 1:
                         wkt += ","
+    
+    else:
+        raise ValueError("No tracks were found inside the gpx file")
 
-    elif len(gpx.routes) > 0:
-        for route in gpx.routes:
-            for index, point in enumerate(route.points):
-                wkt += f"{point.longitude} {point.latitude}"
-                if index < len(route.points) - 1:
-                    wkt += ","
+    start_time = gpx.tracks[0].segments[0].points[0].time
+    end_time = gpx.tracks[0].segments[0].points[-1].time
+    time_sec = (end_time - start_time).seconds
 
+
+    # elif len(gpx.routes) > 0:
+    #     for route in gpx.routes:
+    #         for index, point in enumerate(route.points):
+    #             wkt += f"{point.longitude} {point.latitude}"
+    #             if index < len(route.points) - 1:
+    #                 wkt += ","
+
+    attributes = {}
     wkt += ")"
-    return wkt
+    attributes["wkt"] = wkt
+    attributes["start_time"] = start_time
+    attributes["time_sec"] = time_sec
+    return attributes

--- a/running_dashboard/views.py
+++ b/running_dashboard/views.py
@@ -25,7 +25,7 @@ from running_dashboard.forms import AddRunForm
 from running_dashboard.forms import SignUpForm
 from running_dashboard.models import Run
 from running_dashboard.tokens import account_activation_token
-from running_dashboard.util import gpxToWkt
+from running_dashboard.util import attributesFromGpx
 
 @login_required
 def index(request):
@@ -80,7 +80,7 @@ def change_run_duration(request, pk):
 def addNewRun(request):
     """
     This view allows a user to add a new run and associate it with their account.
-    The view renders a form with inputs for the start time, duration of the run and the route.
+    The view renders a form with input for the gpx file.
     If the form doesn't pass validations it is rendered again with errors.
     If the form passes all validations, the run is added to the db and the user is redirected
     to the home page.
@@ -91,14 +91,15 @@ def addNewRun(request):
         form = AddRunForm(request.POST, request.FILES)
 
         if form.is_valid():
-            start_time = form.cleaned_data['start_time']
-            time_sec = form.cleaned_data['time_sec']
-            route = form.cleaned_data['route']
+            gpx_file = form.cleaned_data['gpx_file']
+            start_time = gpx_file['start_time']
+            time_sec = gpx_file['time_sec']
+            route = gpx_file['wkt']
             runner = request.user
             run = Run(time_sec=time_sec, start_time=start_time, route=route, runner=runner)
             run.save()
 
-            return HttpResponseRedirect(reverse('index'))
+            return HttpResponseRedirect(reverse('run-detail', args=[run.id]))
 
     else:
         form = AddRunForm()


### PR DESCRIPTION
1. Remove time_sec and start_time from the Add Run form
2. Retreive time_sec and start_time directly from track values within the gpx file
3. Only retreive gps data from track and not from route
4. After succesfully adding run, redirect to run detail page instead of home page

closes #26 